### PR TITLE
Fix pull request URLs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -145,7 +145,7 @@ async function main(){
   // Build Pull Request string if required
   let pull_requests = ""
   for(let pull_request of workflow_run.data.pull_requests){
-    pull_requests += ", <"+ pull_request.url + "|#" + pull_request.number + "> from `"+pull_request.head.ref+"` to `"+pull_request.base.ref+"`"
+    pull_requests += ", <https://github.com/"+ workflow_run.data.repository.full_name + "/pull/" + pull_request.number + "|#" + pull_request.number + "> from `"+pull_request.head.ref+"` to `"+pull_request.base.ref+"`"
   }
   if(pull_requests != ""){
     pull_requests = pull_requests.substr(1)


### PR DESCRIPTION
Using `pull_request.url` generates a URL like `https://api.github.com/repos/<org>/<repo>/pulls/<number>` which isn't very useful. This commits changes that to `https://github.com/<org>/<repo>/pull/<number>`.