### PR TITLE
Support large workflows with more than 30 jobs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -81,7 +81,8 @@ async function main(): Promise<void> {
   const {data: jobs_response} = await octokit.actions.listJobsForWorkflowRun({
     owner: context.repo.owner,
     repo: context.repo.repo,
-    run_id: context.runId
+    run_id: context.runId,
+    per_page: 100
   })
 
   const completed_jobs = jobs_response.jobs.filter(


### PR DESCRIPTION
The default `listJobsForWorkflowRun` method only loads 30 jobs, so it thinks the run was a success if the failure occurred, say, on the 35th job. This bumps `per_page` up to 100, which is the maximum. A more long-term solution would be to fetch all pages of jobs given the count.

For now, this is causing an issue with one of our biggest workflows which has 47 jobs 😨 .